### PR TITLE
Fix packages_to_swap and Rocky RPM names

### DIFF
--- a/centos2rocky.sh
+++ b/centos2rocky.sh
@@ -76,8 +76,9 @@ generate_rpm_info() {
 
 package_swaps() {
   rpm -e --nodeps "${packages_to_swap[@]}"
-  rpm -ihv ${current_url}/${SUPPORTED_RELEASE}/BaseOS/x86_64/os/Packages/rocky-release-${SUPPORTED_RELEASE}-11.el8.x86_64.rpm \
-           ${current_url}/${SUPPORTED_RELEASE}/BaseOS/x86_64/os/Packages/rocky-repos-${SUPPORTED_MAJOR}-11.el8.x86_64.rpm
+  rpm -ihv ${current_url}/${SUPPORTED_RELEASE}/BaseOS/x86_64/os/Packages/rocky-release-${SUPPORTED_RELEASE}-11.el8.noarch.rpm \
+           ${current_url}/${SUPPORTED_RELEASE}/BaseOS/x86_64/os/Packages/rocky-repos-${SUPPORTED_RELEASE}-11.el8.noarch.rpm \
+           ${current_url}/${SUPPORTED_RELEASE}/BaseOS/x86_64/os/Packages/rocky-gpg-keys-${SUPPORTED_RELEASE}-11.el8.noarch.rpm
   if [ $? -eq 0 ]; then
     echo "Removing dnf cache"
     rm -rf /var/cache/{yum,dnf}

--- a/centos2rocky.sh
+++ b/centos2rocky.sh
@@ -13,13 +13,15 @@ SUPPORTED_RELEASE="8.3"
 SUPPORTED_MAJOR="8"
 current_url=https://mirror.rockylinux.org/rocky
 # These are packages that can be swapped safely over and will have more added over time.
-packages_to_swap=(
+candidates_to_swap=(
   centos-backgrounds \
   centos-indexhtml \
   centos-linux-repos \
   centos-logos \
   centos-gpg-keys \
   centos-linux-release)
+
+  packages_to_swap=($(rpm -q --queryformat="%{NAME}\n" "${candidates_to_swap[@]}" | grep -v "not installed"))
 
 # Release packages that are part of SIG's should be listed below when they are available.
 #sigs_to_swap=()


### PR DESCRIPTION
Attempting to remove uninstalled packages will cause `rpm --erase ...` to fail and the script will exit. In a minimal install `centos-logos` and `centos-backgrounds` are not installed so we should only try to remove swappable packages that are actually installed.

In addition, the `rocky-release`, `rocky-repos` and `rocky-gpg-keys` RPMs appear to be `noarch` and not `x86_64` and the `rocky-repos` RPM uses the full `RELEASE` identifier not just the `MAJOR` number.