### PR TITLE
Use tput for colors.

### DIFF
--- a/centos2rocky.sh
+++ b/centos2rocky.sh
@@ -7,9 +7,9 @@
 (
 # Pass everything to a subshell so the output can be piped to /var/log/centos2rocky.log
 
-errcolor="\033[3;35m"
-nocolor="\033[0m"
-blue="\033[1;35m"
+errcolor=$(tput setaf 1)
+nocolor=$(tput op)
+blue=$(tput setaf 4)
 
 set -e
 unset CDPATH


### PR DESCRIPTION
Color codes may vary from one terminal to another.  Use tput to always get the
right codes for the terminal in use.