### PR TITLE
Fix migrate2rocky on EFI systems

### DIFF
--- a/migrate2rocky.sh
+++ b/migrate2rocky.sh
@@ -521,7 +521,7 @@ EOF
 fix_efi () (
     grub2-mkconfig -o /boot/efi/EFI/rocky/grub.cfg ||
     	exit_message "Error updating the grub config."
-    efibootmgr -c -d "$efi_mount" -L "Rocky Linux" -I /EFI/rocky/grubx64.efi ||
+    efibootmgr -c -d "$efi_mount" -L "Rocky Linux" -l /EFI/rocky/grubx64.efi ||
 	exit_message "Error updating uEFI firmware."
 )
 


### PR DESCRIPTION
While the recent patches from @pajamian nearly make EFI conversion work, there are two bugs that prevent it from working. This branch fixes them and improves usability by not requiring the user to manually activate EFI conversion.