### PR TITLE
Continues on empty lines from repoquery

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -265,7 +265,7 @@ repoinfo () {
     fi
     declare -gA repoinfo_results=()
     while IFS=" :" read -r name val; do
-	if [[ -z $name ]] && [[ -z $val ]]; then
+	if [[ ! ( $name || $val) ]]; then
 		continue
 	fi
 	if [[ -z $name ]]; then

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -265,6 +265,9 @@ repoinfo () {
     fi
     declare -gA repoinfo_results=()
     while IFS=" :" read -r name val; do
+	if [[ -z $name ]] && [[ -z $val ]]; then
+		continue
+	fi
 	if [[ -z $name ]]; then
 	    repoinfo_results[$prev]+=" $val"
 	else


### PR DESCRIPTION
Had an issue where the script was breaking due to empty lines from repoquery.

This merge adds a conditional check to make sure that both variables are not empty when interpreting repoquery results.