### PR TITLE
Add mapping for rocky-logos-httpd

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -432,6 +432,7 @@ collect_system_info () {
 	[rocky-indexhtml]=redhat-indexhtml
 	[rocky-repos]="$baseos_filename"
 	[rocky-logos]=system-logos
+	[rocky-logos-httpd]=system-logos-httpd
 	[rocky-gpg-keys]="$baseos_gpgkey"
 	[rocky-release]=system-release
     )


### PR DESCRIPTION
As of writing, the `centos-logos-httpd` RPM package is not migrated to `rocky-logos-httpd`…