### PR TITLE
Specify partition when creating EFI entry

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -351,10 +351,12 @@ collect_system_info () {
     # Check the efi mount first, so we can bail before wasting time on all these
     # other checks if it's not there.
     if [[ $update_efi ]]; then
-	declare -g efi_mount
+	declare -g efi_mount efi_disk efi_disk_part
 	efi_mount=$(findmnt --mountpoint /boot/efi --output SOURCE \
 	    --noheadings) ||
-	    exit_message "Can't find EFI mount.  No EFI  boot detected."
+	    exit_message "Can't find EFI mount.  No EFI boot detected."
+	efi_disk=$(echo "${efi_mount}" | sed -re 's/(p|)[0-9]$//g')
+	efi_disk_part=${efi_mount: -1}
     fi
 
     # check if EFI secure boot is enabled
@@ -773,7 +775,7 @@ efi_check () {
 fix_efi () (
     grub2-mkconfig -o /boot/efi/EFI/rocky/grub.cfg ||
     	exit_message "Error updating the grub config."
-    efibootmgr -c -d "$efi_mount" -L "Rocky Linux" -l /EFI/rocky/grubx64.efi ||
+    efibootmgr -c -d "$efi_disk" -p "$efi_disk_part" -L "Rocky Linux" -l /EFI/rocky/grubx64.efi ||
 	exit_message "Error updating uEFI firmware."
 )
 


### PR DESCRIPTION
Resolves #49 

This corrects the creation of the new EFI entry when the EFI mount is not on the first partition of the disk.  The disk name and partition number will be separated to add the correct entry.

**EFI Mount:**
```
[root@server ~]# findmnt --mountpoint /boot/efi --output SOURCE --noheadings
/dev/sdb2
```

**Partition List:**
```
[root@server ~]# blkid
/dev/sdb1: UUID="7a6bb05a-0794-8b27-9ab6-5202a0d1123a" UUID_SUB="f9a82a2f-343e-3b71-7fd4-ef1bae7618f9" LABEL="localhost.localdomain:0" TYPE="linux_raid_member" PARTUUID="e72492d1-1442-45f6-b321-ddf06f54e248"
/dev/sdb2: SEC_TYPE="msdos" UUID="C97A-BA35" BLOCK_SIZE="512" TYPE="vfat" PARTUUID="99b40767-4f6a-4006-85e7-a922638a8e33"
/dev/sdb3: UUID="9fcfce30-34df-7261-617b-2ee252a2c0da" UUID_SUB="087ed481-2114-b170-78c8-cb1a84c2c997" LABEL="localhost.localdomain:1" TYPE="linux_raid_member" PARTUUID="64ff1122-0b99-46a8-87c2-390bdb887106"
```

**Old:**
`Boot0007* Rocky Linux   HD(1,GPT,e72492d1-1442-45f6-b321-ddf06f54e248,0x800,0x1f4000)/File(\EFI\rocky\grubx64.efi)`

**New:**
`Boot0007* Rocky Linux   HD(2,GPT,99b40767-4f6a-4006-85e7-a922638a8e33,0x1f4800,0x64000)/File(\EFI\rocky\grubx64.efi)`

Partition number extraction looks to work for the various naming schemes,

| Mount  | Disk | Partition # |
| ------------- | ------------- | ------------- |
| /dev/sdb2  | /dev/sdb | 2 |
| /dev/mmcblk3p4 | /dev/mmcblk3 | 4 |
| /dev/nvme2n5p3 | /dev/nvme2n5 | 3 |