### PR TITLE
Force en_US.UTF-8

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -105,7 +105,7 @@ errmsg () {
     printf '%s%s%s' "$errcolor" "$msg" "$nocolor" >&4
 }
 
-export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8 LANGUAGE=en_US
 shopt -s nullglob
 
 SUPPORTED_MAJOR="8"


### PR DESCRIPTION
In order to properly parse output from certain commands we must ensure that
output is in the correct locale and character set.  Previously we had just set
LANG but that doesn't force the issue and some systems may still have issues.
While this change will override a person's foreign language preferences this is
preferable to it causing a failed migration.