### PR TITLE
Dump DNF cache before collecting system data and dnf update instead of after.

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -358,6 +358,9 @@ safednf () (
 )
 
 collect_system_info () {
+    # Dump the DNF cache first so we start with a clean slate.
+    infomsg $'\nRemoving dnf cache\n'
+    rm -rf /var/cache/{yum,dnf}
     # Check the efi mount first, so we can bail before wasting time on all these
     # other checks if it's not there.
     if [[ $update_efi ]]; then
@@ -725,8 +728,6 @@ EOF
     fi
 
     # Distrosync
-    infomsg $'\nRemoving dnf cache\n'
-    rm -rf /var/cache/{yum,dnf}
     infomsg $'Ensuring repos are enabled before the package swap\n'
     safednf -y --enableplugin=config-manager config-manager \
 	--set-enabled "${!repo_map[@]}" || {


### PR DESCRIPTION
If there's going to be errors due to corrupted repos, etc we want to find out
right away so we can bail before we put the system in an unstable state.  To
this end we dump the dnf cache right away to make sure that dnf is forced to hit
the repos instead of relying on cached data.