### PR TITLE
Map OracleLinux stream names to RHEL. 

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -409,6 +409,14 @@ collect_system_info () {
 	libselinux-python:2.8
     )
 
+    # Some OracleLinux modules have stream names of ol8 instead of rhel8 and ol
+    # instead of rhel.  This is a map that does a glob match and replacement.
+    local -A module_re_map
+    module_glob_map=(
+	['%:ol8']=:rhel8
+	['%:ol']=:rhel
+    );
+
     # We need to map rockylinux repository names to the equivalent repositories
     # in the source distro.  To do that we look for known packages in each
     # repository and see what repo they came from.  We need to use repoquery for
@@ -556,6 +564,15 @@ $'because continuing with the migration could cause further damage to system.'
     	' | sort -u
 	set +e +o pipefail
     )
+
+    # Map the known module name differences.
+    for i in "${!enabled_modules[@]}"; do
+	for gl in "${!module_glob_map[@]}"; do
+	    repl=${module_glob_map[$gl]}
+	    enabled_modules[$i]=${enabled_modules[$i]/$gl/$repl}
+	done
+    done
+
     # Remove entries matching any excluded modules.
     if (( ${#module_excludes[@]} )); then
 	printf '%s\n' '' "Excluding modules:" "${module_excludes[@]}"

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -411,7 +411,7 @@ collect_system_info () {
 
     # Some OracleLinux modules have stream names of ol8 instead of rhel8 and ol
     # instead of rhel.  This is a map that does a glob match and replacement.
-    local -A module_re_map
+    local -A module_glob_map
     module_glob_map=(
 	['%:ol8']=:rhel8
 	['%:ol']=:rhel

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -566,11 +566,18 @@ $'because continuing with the migration could cause further damage to system.'
     )
 
     # Map the known module name differences.
+    disable_modules=()
+    local i gl repl mod
     for i in "${!enabled_modules[@]}"; do
+	mod=${enabled_modules[$i]}
 	for gl in "${!module_glob_map[@]}"; do
 	    repl=${module_glob_map[$gl]}
-	    enabled_modules[$i]=${enabled_modules[$i]/$gl/$repl}
+	    mod=${mod/$gl/$repl}
 	done
+	if [[ $mod != ${enabled_modules[$i]} ]]; then
+	    disable_modules+=(${enabled_modules[$i]})
+	    enabled_modules[$i]=$mod
+	fi
     done
 
     # Remove entries matching any excluded modules.
@@ -762,6 +769,12 @@ EOF
 	    safednf -y --enableplugin=config-manager config-manager \
 		--disable "${managed_repos[@]}"
 	fi
+    fi
+
+    if (( ${#disable_modules[@]} )); then
+	infomsg $'Disabling modules\n\n'
+	safednf -y module disable "${disable_modules[@]}" ||
+	    exit_message "Can't disable modules ${disable_modules[*]}"
     fi
 
     if (( ${#enabled_modules[@]} )); then


### PR DESCRIPTION
OracleLinux renames a number of module streams from rhel8 to ol8 and from rhel
to ol.  This commit maps the names back to rhel8 and rhel so that migrate2rocky
doesn't blow up on them.
