### PR TITLE
Add -L to curl command

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -884,7 +884,7 @@ establish_gpg_trust () {
     # extract the filename from the url, use the temp dir just created
     declare -g gpg_key_file="$gpg_tmp_dir/${gpg_key_url##*/}"
 
-    if ! curl -o "$gpg_key_file" --silent --show-error "$gpg_key_url"; then
+    if ! curl -L -o "$gpg_key_file" --silent --show-error "$gpg_key_url"; then
 	rm -rf "$gpg_tmp_dir"
 	exit_message "Error downloading the Rocky Linux signing key."
     fi


### PR DESCRIPTION
curl won't follow redirects without -L.  Since redirects are used by some who
have a private repository this breaks curl in those instances.  Adding -L fixes
the problem.