### PR TITLE
Use C locale instead of en_US 

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -105,7 +105,8 @@ errmsg () {
     printf '%s%s%s' "$errcolor" "$msg" "$nocolor" >&4
 }
 
-export LC_ALL=en_US.UTF-8 LANGUAGE=en_US
+export LC_ALL=C.UTF-8
+unset LANGUAGE
 shopt -s nullglob
 
 SUPPORTED_MAJOR="8"


### PR DESCRIPTION
en_US is not guaranteed to be installed on all systems, but C is, so we use the
C locale to guarantee that all the dnf and rpm command output parses properly.
