### PR TITLE
Add note about mitigating Java alternatives issue before IPA issue.

### DIFF
--- a/migrate2rocky/README.md
+++ b/migrate2rocky/README.md
@@ -82,6 +82,9 @@ fix this issue run the following command after migration:
 ```
 ipa-server-upgrade --skip-version-check
 ```
+> Note: Since ipa-server-upgrade is a java program you will likely have to run
+> the command to mitigate the "Symbolic links to Java programs..." issue above
+> before running this command.
 
 #### CentOS SIG repositories disappear after migrating to RockyLinux.
 


### PR DESCRIPTION
ipa-server-upgrade is a java program, and as such is subject to the issue with
Java alternatives mentioned earlier in Known Issues.  Add a note to reference
mitigating the issue with Java alternatives before attempting to run
ipa-server-upgrade.