### PR TITLE
Mirrorsync.sh updates

### DIFF
--- a/mirror/mirrorsync.sh
+++ b/mirror/mirrorsync.sh
@@ -35,10 +35,12 @@
 # You can change v to q if you do not want detailed logging
 opts=(-vrlptDSH --exclude="*.~tmp~" --delete-delay --delay-updates)
 
-# Please use a mirror next to you for initial sync
-# or if you are hosting a private rather than a pulic mirror.
-# Local mirrors might be faster.
-# Also we might restrict access to the master in the future.
+# Please use a mirror geographically close to you for initial sync,
+# or if you are hosting a private mirror(not publicly available).
+#
+# Note that local mirrors may be faster, and we might restrict
+# access to the master in the future.
+#
 # A complete list of mirrors can be found at
 # https://mirrors.rockylinux.org/mirrormanager/mirrors/Rocky
 src="msync.rockylinux.org::rocky/mirror/pub/rocky"

--- a/mirror/mirrorsync.sh
+++ b/mirror/mirrorsync.sh
@@ -31,7 +31,8 @@
 # SOFTWARE.
 #
 
-
+# Find rsync in path or use "/usr/bin/rsync".
+rsync=$(which rsync || /usr/bin/rsync)
 # You can change v to q if you do not want detailed logging
 opts=(-vrlptDSH --exclude="*.~tmp~" --delete-delay --delay-updates)
 
@@ -56,7 +57,7 @@ logfile="$0.log"
 
 # Check if the filelistfile has changed on upstream mirror
 # and exit cleanly if it is still the same
-checkresult=$(rsync --no-motd --dry-run --out-format="%n" "${src}/${filelistfile}" "${dst}/${filelistfile}")
+checkresult=$(${rsync} --no-motd --dry-run --out-format="%n" "${src}/${filelistfile}" "${dst}/${filelistfile}")
 if [[ -z "$checkresult" ]]; then
 	printf "%s unchanged. Not updating at %(%c)T\n" "$filelistfile" -1 >> "$logfile" 2>&1
 	logger -t rsync "Not updating ${mirrormodule}: ${filelistfile} unchanged."
@@ -79,7 +80,7 @@ fi
 printf '%s\n' "$$" > "$lockfile"
 printf "Started update at %(%c)T\n" -1 >> "$logfile" 2>&1
 logger -t rsync "Updating ${mirrormodule}"
-rsync "${opts[@]}" "${src}/" "${dst}/" >> "$logfile" 2>&1
+${rsync} "${opts[@]}" "${src}/" "${dst}/" >> "$logfile" 2>&1
 logger -t rsync "Finished updating ${mirrormodule}"  
 printf "End: %(%c)T\n" -1 >> "$logfile" 2>&1
 rm -f "$lockfile"

--- a/mirror/mirrorsync.sh
+++ b/mirror/mirrorsync.sh
@@ -55,12 +55,12 @@ lockfile="$0.lockfile"
 logfile="$0.log"
 
 # Check if the filelistfile has changed on upstream mirror
-# and exit if it is still the same
+# and exit cleanly if it is still the same
 checkresult=$(rsync --no-motd --dry-run --out-format="%n" "${src}/${filelistfile}" "${dst}/${filelistfile}")
 if [[ -z "$checkresult" ]]; then
 	printf "%s unchanged. Not updating at %(%c)T\n" "$filelistfile" -1 >> "$logfile" 2>&1
 	logger -t rsync "Not updating ${mirrormodule}: ${filelistfile} unchanged."
-	exit 1
+	exit 0
 fi
 
 # Check for existing lockfile to avoid multiple simultaneously running syncs


### PR DESCRIPTION
Crusher4 mentioned that the sync script is exiting 1 instead of 0 when a mirror sync is ran but no files are transferred, because the files have not changed from upstream. I've modified the script to exit 0 instead in that eventuality. Original conversation here: https://chat.rockylinux.org/rocky-linux/pl/38eprkx15tdy5cbhirb34jmd5e

I've also included a commit that specifies the rsync binary path, as I ran into an issue where the sync was not running from cron without an explicit path. This would prevent that from happening, although I realize that is an edge case at best.

Further, following a discussion about possibly limiting access to the primary upstream mirror for "everyone", I've included a commit that draws attention that that warning.