### PR TITLE
Fix shellcheck issues

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,11 +16,6 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v2
 
-      - name: Upgrade shellcheck to latest available release in ubuntu
-        run: |
-          sudo apt-get update
-          sudo apt-get install shellcheck
-
       - name: Shellcheck!
         run: |
           shellcheck migrate2rocky/migrate2rocky.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v2
 
+      - name: Upgrade shellcheck to latest available release in ubuntu
+        run: |
+          sudo apt-get update
+          sudo apt-get install shellcheck
+
       - name: Shellcheck!
         run: |
           shellcheck migrate2rocky/migrate2rocky.sh

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -479,12 +479,9 @@ collect_system_info () {
             --noheadings) ||
             exit_message "Can't find EFI mount.  No EFI  boot detected."
         kname=$(lsblk -dno kname "$efi_mount")
-        # shellcheck disable=SC2178
         efi_disk=$(lsblk -dno pkname "/dev/$kname")
 
-        # shellcheck disable=SC2128
         if [[ $efi_disk ]]; then
-            # shellcheck disable=SC2178
             efi_partition=$(<"/sys/block/$efi_disk/$kname/partition")
         else
             # This is likely an md-raid or other type of virtual disk, we need

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -212,6 +212,7 @@ logmessage(){
 
 # This just grabs a field from os-release and returns it.
 os-release () (
+    # shellcheck source=/dev/null
     . /etc/os-release
     if ! [[ ${!1} ]]; then
         return 1

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -283,6 +283,7 @@ pre_check () {
 
 	dir=${dirs[$((i++))]}
 
+        # shellcheck disable=SC2034
 	dir_mount_map[$dir]=$mount
 	mount_avail_map[$mount]=${avail%M}
 	(( mount_space_map[$mount]+=dir_space_map[$dir] ))

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -283,7 +283,6 @@ pre_check () {
 
 	dir=${dirs[$((i++))]}
 
-        # shellcheck disable=SC2034
 	dir_mount_map[$dir]=$mount
 	mount_avail_map[$mount]=${avail%M}
 	(( mount_space_map[$mount]+=dir_space_map[$dir] ))

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -480,9 +480,12 @@ collect_system_info () {
             --noheadings) ||
             exit_message "Can't find EFI mount.  No EFI  boot detected."
         kname=$(lsblk -dno kname "$efi_mount")
+        # shellcheck disable=SC2178
         efi_disk=$(lsblk -dno pkname "/dev/$kname")
 
+        # shellcheck disable=SC2128
         if [[ $efi_disk ]]; then
+            # shellcheck disable=SC2178
             efi_partition=$(<"/sys/block/$efi_disk/$kname/partition")
         else
             # This is likely an md-raid or other type of virtual disk, we need

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -843,6 +843,7 @@ package_swaps() {
         fi
 
         # Rename the stream repos with a prefix and fix the baseurl.
+        # shellcheck disable=SC2016
         sed -i \
             -e 's/^\[/['"$stream_prefix"'/' \
             -e 's|^mirrorlist=|#mirrorlist=|' \

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -479,10 +479,10 @@ collect_system_info () {
             --noheadings) ||
             exit_message "Can't find EFI mount.  No EFI  boot detected."
         kname=$(lsblk -dno kname "$efi_mount")
-        efi_disk=$(lsblk -dno pkname "/dev/$kname")
+        efi_disk=("$(lsblk -dno pkname "/dev/$kname")")
 
-        if [[ $efi_disk ]]; then
-            efi_partition=$(<"/sys/block/$efi_disk/$kname/partition")
+        if [[ ${efi_disk[0]} ]]; then
+	    efi_partition=("$(<"/sys/block/$efi_disk/$kname/partition")")
         else
             # This is likely an md-raid or other type of virtual disk, we need
             # to dig a little deeper to find the actual physical disks and

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -275,7 +275,7 @@ pre_check () {
     fi
     local -a errs dirs=("${!dir_space_map[@]}")
     local dir mount avail i=0
-    local -A mount_avail_map dir_mount_map mount_space_map
+    local -A mount_avail_map mount_space_map
     while read -r mount avail; do 
 	if [[ $mount == 'Filesystem' ]]; then
 	    continue
@@ -283,7 +283,6 @@ pre_check () {
 
 	dir=${dirs[$((i++))]}
 
-	dir_mount_map[$dir]=$mount
 	mount_avail_map[$mount]=${avail%M}
 	(( mount_space_map[$mount]+=dir_space_map[$dir] ))
     done < <(df -BM --output=source,avail "${dirs[@]}")

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -482,7 +482,7 @@ collect_system_info () {
         efi_disk=("$(lsblk -dno pkname "/dev/$kname")")
 
         if [[ ${efi_disk[0]} ]]; then
-	    efi_partition=("$(<"/sys/block/$efi_disk/$kname/partition")")
+	    efi_partition=("$(<"/sys/block/${efi_disk[0]}/$kname/partition")")
         else
             # This is likely an md-raid or other type of virtual disk, we need
             # to dig a little deeper to find the actual physical disks and

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -665,10 +665,10 @@ $'because continuing with the migration could cause further damage to system.'
         then
             # System package that needs to be swapped / disabled
             installed_pkg_map[$p]=
-            installed_sys_stream_repos_pkgs+=( ${stream_repos_pkgs[$p]} )
+            installed_sys_stream_repos_pkgs+=( "${stream_repos_pkgs[$p]}" )
         elif rpm --quiet -q "${stream_repos_pkgs[$p]}"; then
             # Non-system package, repos just need to be disabled.
-            installed_stream_repos_pkgs+=( ${stream_repos_pkgs[$p]} )
+            installed_stream_repos_pkgs+=( "${stream_repos_pkgs[$p]}" )
         fi
     done
 
@@ -735,7 +735,7 @@ $'because continuing with the migration could cause further damage to system.'
             mod=${mod/$gl/$repl}
         done
         if [[ $mod != "${enabled_modules[$i]}" ]]; then
-            disable_modules+=(${enabled_modules[$i]})
+            disable_modules+=("${enabled_modules[$i]}")
             enabled_modules[$i]=$mod
         fi
     done


### PR DESCRIPTION
Merging these will prevent `shellcheck migrate2rocky/migrate2rocky.sh --severity=warning` to returns non-zero.

There are a few `info` severity issues which can be fixed later (or not:))