### PR TITLE
Information about resolving sysroot error

### DIFF
--- a/migrate2rocky/README.md
+++ b/migrate2rocky/README.md
@@ -118,6 +118,22 @@ package for the repo that you need):
 rpm2cpio <(curl http://mirror.centos.org/centos/8/extras/x86_64/os/Packages/centos-release-gluster9-1.0-1.el8.noarch.rpm) | cpio -iD/ \*.repo
 ```
 
+#### Error "specified switch root path /sysroot does not seem to be an os tree"
+
+This issue is caused by a GRUB issue after installation. Has been seen on Hetzner Dedicated Server upgrades from CentOS 8.4 -> Rocky 8.X
+In order to resolve this issue, boot your dedicated server into a rescue system (for example, hetzner rescue system)
+From here, you need to locate your partitions via `fdisk -l` and mount your `/` partition into a directory of your choosing (or `/mnt`).
+
+Run the following commands (be sure to change the "mnt" to the directory of your mounted drives).
+```
+mount --rbind /dev  /mnt/dev
+mount --rbind /proc /mnt/proc
+mount --rbind /sys  /mnt/sys
+chroot /mnt
+
+grub2-mkconfig -o /boot/grub2/grub.cfg
+```
+
 ### Latest Version
 
 The latest version of this script can be found [here](https://github.com/rocky-linux/rocky-tools/).


### PR DESCRIPTION
From testing on a few dedicated server providers, I ran into an issue with GRUB not working properly after the upgrade to RockyLinux 8.5
Example error message:
![image](https://user-images.githubusercontent.com/44349634/151680279-1dc1f73a-623e-4092-b10a-126e53ab3e54.png)
![image](https://user-images.githubusercontent.com/44349634/151680284-6e552682-9b28-4d68-b5b7-523e07f60e93.png)

This is fixable by remounting all drives within a rescue system, then rebuilding grub cfg. 