### PR TITLE
Fix issue where we didn't exit when we were supposed to.

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -357,11 +357,9 @@ bin_check() {
 # as a special-case below to avoid having the extras repository map to epel.
 repoquery () {
     local name val prev result
-    result=$(
-        safednf -y -q "${dist_repourl_swaps[@]}" \
-	    --setopt=epel.excludepkgs=epel-release repoquery -i "$1" ||
-            exit_message "Failed to fetch info for package $1."
-    )
+    result=$(safednf -y -q "${dist_repourl_swaps[@]}" \
+	--setopt=epel.excludepkgs=epel-release repoquery -i "$1") ||
+    	exit_message "Failed to fetch info for package $1."
     if ! [[ $result ]]; then
         # We didn't match this package, the repo could be disabled.
         return 1


### PR DESCRIPTION
Exiting from a subshell doesn't actually exit the script.  Move the exit to
outside of the subshell.