### PR TITLE
Fix grub.

### DIFF
--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -1212,6 +1212,9 @@ efi_check () {
     elif [[ -d /sys/firmware/efi/ ]]; then
         declare -g update_efi
         update_efi=true
+    else
+        declare -g update_bios
+        update_bios=true
     fi
 }
 
@@ -1305,6 +1308,8 @@ fi
 
 if [[ $update_efi && $convert_to_rocky ]]; then
     fix_efi
+elif [[ $update_bios && $convert_to_rocky ]]; then
+    grub2-mkconfig -o /boot/grub2/grub.cfg
 fi
 
 printf '\n\n\n'


### PR DESCRIPTION
On a machine that is UEFI capable, but boots in old-school BIOS mode, the system is rendered unbootable if you do not update grub. This patch has been tested and fixes that issue.