### PR TITLE
Added offline and no-pre-update mode

### DIFF
--- a/migrate2rocky/README.md
+++ b/migrate2rocky/README.md
@@ -63,16 +63,30 @@ sed -i -r \
 
 #### Migration in offline mode
 
-Offline mode has received minimal testing and only in the CentOS 8.5 -> Rocky 8.5
-migration from a pristine system using a mounted CentOS 8.5 DVD ISO and a Rocky 8.5
-ISO as offline repositories, mounted respectively under /mnt/centos and /mnt/rocky 
-(these pathnames are hardcoded into the script).
+Offline mode has received minimal testing and only for the CentOS 8.5 -> Rocky 8.5/8.6
+migration from a minimal (straight from installation or fully updated) system using a mounted
+CentOS 8.5 DVD ISO and a Rocky 8.5/8.6 ISO as offline repositories, mounted respectively
+under /mnt/centos and /mnt/rocky - these local pathnames are hardcoded into (and forced by) the
+script for the CentOS case, while for other distros you will need to manually define local
+repo paths under /etc/yum.repos.d/ before launching the script.
+Please make sure that you do not inadvertently swap the former-distro/Rocky local repositories
+when mounting ISOs.
+Package downgrades may happen, depending on the update status of the running distro and
+on the content of the local repositories (e.g. using a Rocky 8.5 mounted ISO for offline
+updating a CentOS 8.5 with all latest updates applied before EOL).
+Note that if you are disabling pre-migration updates then you will need only the base repositories'
+metadata (repodata subdir) for the currently running distro (can be copied from original
+installation ISO).
+If you installed packages from further repos of the running distro (devel, extras, ha, powertools)
+then you will need the same repos enabled and the corresponding local repos from Rocky
+available (under /mnt/rocky/{Extras,HA,PowerTools,Devel}) before starting the migration,
+otherwise make sure that those additional repos are disabled.
 
-#### Migration with updating disabled
+#### Migration with pre-updating disabled
 
-Disabling running system update before migration has been introduced as a
-convenience option for the offline conversion mode but it should be carefully
-tested on a non-production system before attempting it even in offline mode.
+Disabling system updates before migration has been introduced as a convenience option
+mainly for the offline migration mode but it should be carefully tested on a non-production
+system before attempting it even in offline mode.
 
 #### Custom replacements of default repositories
 

--- a/migrate2rocky/README.md
+++ b/migrate2rocky/README.md
@@ -64,38 +64,42 @@ sed -i -r \
 #### Migration in offline mode
 
 Offline mode has received minimal testing and only for the CentOS 8.5 -> Rocky 8.5/8.6
-migration from a minimal (straight from installation or fully updated) system using a mounted
-CentOS 8.5 DVD ISO and a Rocky 8.5/8.6 ISO as offline repositories, mounted respectively
-under /mnt/centos and /mnt/rocky - these local pathnames are hardcoded into (and forced by) the
-script for the CentOS case, while for other distros you will need to manually define local
-repo paths under /etc/yum.repos.d/ before launching the script.
-Please make sure that you do not inadvertently swap the former-distro/Rocky local repositories
+migration from a minimal (straight from installation or fully updated) system using
+CentOS 8.5 DVD and  Rocky 8.5/8.6 DVD ISOs as offline repositories, mounted respectively
+under /mnt/centos (hardcoded into and forced by the script only for the CentOS case - for other
+EL8 distros you will need to manually define local repo paths under /etc/yum.repos.d/ before
+launching the script) and /mnt/rocky (hardcoded into and always forced by the script) .
+
+Please make sure that you do not inadvertently swap the current-EL8/Rocky local repositories
 when mounting ISOs.
-Package downgrades may happen, depending on the update status of the running distro and
-on the content of the local repositories (e.g. using a Rocky 8.5 mounted ISO for offline
-updating a CentOS 8.5 with all latest updates applied before EOL).
+
+Package downgrades may happen, depending on the update status of the running EL8 distro and
+on the content of the local repositories (e.g. using a Rocky 8.5 DVD ISO for offline
+migrating a CentOS 8.5 with all latest-before-EOL updates applied).
 Note that if you are disabling pre-migration updates then you will need only the base repositories'
-metadata (repodata subdir) for the currently running distro (can be copied from original
+metadata (repodata subdir) for the currently running EL8 (can be copied from original
 installation ISO).
-If you installed packages from further repos of the running distro (devel, extras, ha, powertools)
-then you will need the same repos enabled and the corresponding local repos from Rocky
-available (under /mnt/rocky/{Extras,HA,PowerTools,Devel}) before starting the migration,
+
+If you installed packages from further repos of the running EL8 distro (devel, extras, ha, powertools)
+then you will need those same repos enabled and their Rocky equivalents locally available 
+(under /mnt/rocky/{Extras,HA,PowerTools,Devel}) before starting the migration,
 otherwise make sure that those additional repos are disabled.
 
 #### Migration with pre-updating disabled
 
-Disabling system updates before migration has been introduced as a convenience option
-mainly for the offline migration mode but it should be carefully tested on a non-production
-system before attempting it even in offline mode.
+Disabling system updates before migration has been introduced and tested only as a convenience
+option for the offline migration mode but it should be carefully tested on a non-production
+system before attempting it.
 
 #### Custom replacements of default repositories
 
 This script expects the **original repository configuration being present, as
 well as enabled** (i.e. for CentOS the `baseos` repo configuration in the
 `/etc/yum.repos.d/CentOS-Linux-BaseOS.repo` file has to be present and enabled).
-Offline mode will require at least the repository metadata for the `baseos` and
-`appstream` repos to be available (for CentOS under /mnt/centos/{BaseOS,AppStream}
-which can be copied or mounted from a CentOS ISO).
+Offline mode will require at least the repository metadata (repodata subdir) for
+the `baseos` and `appstream` repos to be available (for CentOS their path is
+hardcoded as /mnt/centos/{BaseOS,AppStream} and can be copied or mounted from a
+CentOS ISO).
 Also make sure that there are **no other repositories** which could interfere
 with the original configuration.
 

--- a/migrate2rocky/README.md
+++ b/migrate2rocky/README.md
@@ -7,7 +7,9 @@ Running this script will convert an existing CentOS 8 system to Rocky Linux 8.
 
 ```bash
 ./migrate2rocky.sh -h
+├── -d   # --> Do not update before conversion
 ├── -h   # --> Display this help
+├── -o   # --> Work in offline mode
 ├── -r   # --> Convert to Rocky
 └── -V   # --> Verify switch
 
@@ -17,8 +19,9 @@ Running this script will convert an existing CentOS 8 system to Rocky Linux 8.
 ### Disk Space Requirements
 
 Please note the following disk space requirements.  These requirements may vary
-from one system to another.  Failure to have adequate disk space available may
-result in migrate2rocky leaving the system in an unstable state:
+from one system to another.  Offline mode may require further space for rpm
+packages and repository metadata.  Failure to have adequate disk space available
+may result in migrate2rocky leaving the system in an unstable state:
 
 ```
 /usr   250M
@@ -58,11 +61,27 @@ sed -i -r \
     /etc/yum.repos.d/CentOS-*.repo
 ```
 
+#### Migration in offline mode
+
+Offline mode has received minimal testing and only in the CentOS 8.5 -> Rocky 8.5
+migration from a pristine system using a mounted CentOS 8.5 DVD ISO and a Rocky 8.5
+ISO as offline repositories, mounted respectively under /mnt/centos and /mnt/rocky 
+(these pathnames are hardcoded into the script).
+
+#### Migration with updating disabled
+
+Disabling running system update before migration has been introduced as a
+convenience option for the offline conversion mode but it should be carefully
+tested on a non-production system before attempting it even in offline mode.
+
 #### Custom replacements of default repositories
 
 This script expects the **original repository configuration being present, as
 well as enabled** (i.e. for CentOS the `baseos` repo configuration in the
 `/etc/yum.repos.d/CentOS-Linux-BaseOS.repo` file has to be present and enabled).
+Offline mode will require at least the repository metadata for the `baseos` and
+`appstream` repos to be available (for CentOS under /mnt/centos/{BaseOS,AppStream}
+which can be copied or mounted from a CentOS ISO).
 Also make sure that there are **no other repositories** which could interfere
 with the original configuration.
 

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -145,6 +145,7 @@ sm_ca_dir=/etc/rhsm/ca
 unset tmp_sm_ca_dir
 
 # all repos must be signed with the same key given in $gpg_key_url
+declare -A rocky_repo_offline_baseurls=()
 declare -A repo_urls
 repo_urls=(
     [rockybaseos]="https://dl.rockylinux.org/pub/rocky/${SUPPORTED_MAJOR}/BaseOS/$ARCH/os/"
@@ -523,7 +524,11 @@ check_repourl () {
     IFS=, read -r -a urls <<<"${repoinfo_results[Repo-baseurl]}"
     local u
     for u in "${urls[@]##*( )}"; do
-	curl -sfLI "${u%% *}repodata/repomd.xml" > /dev/null && return
+        if [[ $offline_mode ]]; then
+            return 1
+        else
+            curl -sfLI "${u%% *}repodata/repomd.xml" > /dev/null && return
+        fi
     done
     return "$(( $? ? $? : 1 ))"
 }
@@ -620,14 +625,25 @@ collect_system_info () {
     # Check to see if we need to change the repourl on any system repositories
     # (CentOS 8)
     local -A dist_repourl_map
-    dist_repourl_map=(
-	[centos:baseos]=https://dl.rockylinux.org/vault/centos/8.5.2111/BaseOS/$ARCH/os/
-	[centos:appstream]=https://dl.rockylinux.org/vault/centos/8.5.2111/AppStream/$ARCH/os/
-	[centos:ha]=https://dl.rockylinux.org/vault/centos/8.5.2111/HighAvailability/$ARCH/os/
-	[centos:powertools]=https://dl.rockylinux.org/vault/centos/8.5.2111/PowerTools/$ARCH/os/
-	[centos:extras]=https://dl.rockylinux.org/vault/centos/8.5.2111/extras/$ARCH/os/
-	[centos:devel]=https://dl.rockylinux.org/vault/centos/8.5.2111/Devel/$ARCH/os/
-    )
+    if [[ $offline_mode ]]; then
+        dist_repourl_map=(
+            [centos:baseos]=file:///mnt/centos/BaseOS/
+            [centos:appstream]=file:///mnt/centos/AppStream/
+            [centos:ha]=file:///mnt/centos/HighAvailability/
+            [centos:powertools]=file:///mnt/centos/PowerTools/
+            [centos:extras]=file:///mnt/centos/extras/
+            [centos:devel]=file:///mnt/centos/Devel/
+        )
+    else
+        dist_repourl_map=(
+            [centos:baseos]=https://dl.rockylinux.org/vault/centos/8.5.2111/BaseOS/$ARCH/os/
+            [centos:appstream]=https://dl.rockylinux.org/vault/centos/8.5.2111/AppStream/$ARCH/os/
+            [centos:ha]=https://dl.rockylinux.org/vault/centos/8.5.2111/HighAvailability/$ARCH/os/
+            [centos:powertools]=https://dl.rockylinux.org/vault/centos/8.5.2111/PowerTools/$ARCH/os/
+            [centos:extras]=https://dl.rockylinux.org/vault/centos/8.5.2111/extras/$ARCH/os/
+            [centos:devel]=https://dl.rockylinux.org/vault/centos/8.5.2111/Devel/$ARCH/os/
+        )
+    fi
 
     # In case migration is attempted from very old CentOS (before the repository
     # names were lowercased)
@@ -642,6 +658,7 @@ collect_system_info () {
     local -a enabled_repos=()
     declare -g -A enabled_repo_check=()
     declare -g -a dist_repourl_swaps=()
+    declare -g -a dist_repourl_offline=()
     readarray -s 1 -t enabled_repos < <(dnf -q -y repolist --enabled)
     for r in "${enabled_repos[@]}"; do
 	enabled_repo_check[${r%% *}]=1
@@ -894,7 +911,7 @@ $'because continuing with the migration could cause further damage to system.'
 }
 
 convert_info_dir=/root/convert
-unset convert_to_rocky reinstall_all_rpms verify_all_rpms update_efi \
+unset dont_update offline_mode convert_to_rocky reinstall_all_rpms verify_all_rpms update_efi \
     container_macros
 
 usage() {
@@ -902,7 +919,9 @@ usage() {
       "Usage: ${0##*/} [OPTIONS]" \
       '' \
       'Options:' \
+      '-d Do not update before conversion' \
       '-h Display this help' \
+      '-o Work in offline mode' \
       '-r Convert to rocky' \
       '-V Verify switch' \
       '   !! USE WITH CAUTION !!'
@@ -972,8 +991,8 @@ package_swaps() {
         sed -i \
             -e 's/^\[/['"$stream_prefix"'/' \
             -e 's|^mirrorlist=|#mirrorlist=|' \
-            -e 's|^#baseurl=http://mirror.centos.org/$contentdir/$stream/|baseurl=http://mirror.centos.org/centos/8-stream/|' \
-            -e 's|^baseurl=http://vault.centos.org/$contentdir/$stream/|baseurl=https://vault.centos.org/centos/8-stream/|' \
+            -e 's|^#baseurl=http://mirror.centos.org/$contentdir/$stream/|baseurl='"${stream_mirror_baseurl}"'|' \
+            -e 's|^baseurl=http://vault.centos.org/$contentdir/$stream/|baseurl='"${stream_vault_baseurl}"'|' \
             "${repos_files[@]}"
     fi
 
@@ -1073,6 +1092,30 @@ EOF
         done
     fi
 
+    # Offline
+    # Map Rocky's repos to offline local repos - temporarily disable a repo if its equivalent was disabled before migration
+    if [[ $offline_mode ]]; then
+        infomsg $'Ensuring offline repos are configured before the package swap\n'
+        dist_repourl_offline+=(
+            "--disablerepo=*"
+        )
+        for k in "${!enabled_repo_check[@]}"; do
+            dist_repourl_offline+=(
+                "--enablerepo=$k"
+            )
+	    for r in "${!pkg_repo_map[@]}"; do
+                if [[ $r = $k ]]; then
+                    dist_repourl_offline+=(
+                        "--setopt=$r.mirrorlist="
+                        "--setopt=$r.metalink="
+                        "--setopt=$r.baseurl="
+                        "--setopt=$r.baseurl=${rocky_repo_offline_baseurls[$r]}"
+                    )
+                fi
+	    done
+        done
+    fi
+
     # Distrosync
     infomsg $'Ensuring repos are enabled before the package swap\n'
     safednf -y --enableplugin=config_manager config-manager \
@@ -1097,23 +1140,23 @@ EOF
 
     if (( ${#disable_modules[@]} )); then
         infomsg $'Disabling modules\n\n'
-        safednf -y module disable "${disable_modules[@]}" ||
+        safednf -y "${dist_repourl_offline[@]}" module disable "${disable_modules[@]}" ||
             exit_message "Can't disable modules ${disable_modules[*]}"
     fi
 
     if (( ${#enabled_modules[@]} )); then
         infomsg $'Enabling modules\n\n'
-        safednf -y module enable "${enabled_modules[@]}" ||
+        safednf -y "${dist_repourl_offline[@]}" module enable "${enabled_modules[@]}" ||
                 exit_message "Can't enable modules ${enabled_modules[*]}"
     fi
 
     # Make sure that excluded modules are disabled.
     infomsg $'Disabling excluded modules\n\n'
-    safednf -y module disable "${module_excludes[@]}" ||
+    safednf -y "${dist_repourl_offline[@]}" module disable "${module_excludes[@]}" ||
             exit_message "Can't disable modules ${module_excludes[*]}"
 
     infomsg $'\nSyncing packages\n\n'
-    dnf -y distro-sync || exit_message "Error during distro-sync."
+    dnf -y "${dist_repourl_offline[@]}" distro-sync || exit_message "Error during distro-sync."
 
     # Disable Stream repos.
     if (( ${#installed_sys_stream_repos_pkgs[@]} ||
@@ -1125,7 +1168,7 @@ $'Failed to disable CentOS Stream repos, please check and disable manually.\n'
 
         if (( ${#stream_always_replace[@]} )) &&
             [[ $(saferpm -qa "${stream_always_replace[@]}") ]]; then
-            safednf -y distro-sync "${stream_always_replace[@]}" ||
+            safednf -y "${dist_repourl_offline[@]}" distro-sync "${stream_always_replace[@]}" ||
                 exit_message "Error during distro-sync."
         fi
 
@@ -1172,7 +1215,7 @@ EOF
     fi
 
     if (( ${#always_install[@]} )); then
-        safednf -y install "${always_install[@]}" || exit_message \
+        safednf -y "${dist_repourl_offline[@]}" install "${always_install[@]}" || exit_message \
             "Error installing required packages: ${always_install[*]}"
     fi
 
@@ -1270,11 +1313,17 @@ establish_gpg_trust () {
 ## End actual work
 
 noopts=0
-while getopts "hrVR" option; do
+while getopts "dhorV" option; do
   (( noopts++ ))
   case "$option" in
+    d)
+      dont_update=true
+      ;;
     h)
       usage
+      ;;
+    o)
+      offline_mode=true
       ;;
     r)
       convert_to_rocky=true
@@ -1292,6 +1341,27 @@ if (( ! noopts )); then
     usage
 fi
 
+if [[ $offline_mode ]]; then
+  gpg_key_url="file:///mnt/RPM-GPG-KEY-rockyofficial"
+  repo_urls=(
+    [rockybaseos]="file:///mnt/rocky/BaseOS/"
+    [rockyappstream]="file:///mnt/rocky/AppStream/"
+  )
+  stream_mirror_baseurl="file:///mnt/centos-stream/"
+  stream_vault_baseurl="file:///mnt/centos-stream-vault/"
+  rocky_repo_offline_baseurls=(
+    [baseos]="file:///mnt/rocky/BaseOS/"
+    [appstream]="file:///mnt/rocky/AppStream/"
+    [ha]="file:///mnt/rocky/HA/"
+    [powertools]="file:///mnt/rocky/PowerTools/"
+    [extras]="file:///mnt/rocky/Extras/"
+    [devel]="file:///mnt/rocky/Devel/"
+  )
+else
+  stream_mirror_baseurl="http://mirror.centos.org/centos/8-stream/"
+  stream_vault_baseurl="https://vault.centos.org/centos/8-stream/"
+fi
+
 pre_setup
 trap exit_clean EXIT
 pre_check
@@ -1305,7 +1375,11 @@ fi
 if [[ $convert_to_rocky ]]; then
     collect_system_info
     establish_gpg_trust
-    pre_update
+    if [[ $dont_update ]]; then
+      infomsg $'\nSkipping update as requested.\n'
+    else
+      pre_update
+    fi
     package_swaps
 fi
 

--- a/migrate2rocky/migrate2rocky.sh
+++ b/migrate2rocky/migrate2rocky.sh
@@ -515,6 +515,10 @@ safednf () (
 # with a good one from our mirror of CentOS vault.
 #
 check_repourl () {
+    if [[ $offline_mode ]]; then
+        return 1
+    fi
+
     repoinfo "$1" || return
     if [[ ! ${repoinfo_results[Repo-baseurl]} ]]; then
 	return 1
@@ -524,11 +528,7 @@ check_repourl () {
     IFS=, read -r -a urls <<<"${repoinfo_results[Repo-baseurl]}"
     local u
     for u in "${urls[@]##*( )}"; do
-        if [[ $offline_mode ]]; then
-            return 1
-        else
-            curl -sfLI "${u%% *}repodata/repomd.xml" > /dev/null && return
-        fi
+	curl -sfLI "${u%% *}repodata/repomd.xml" > /dev/null && return
     done
     return "$(( $? ? $? : 1 ))"
 }
@@ -1103,7 +1103,7 @@ EOF
             dist_repourl_offline+=(
                 "--enablerepo=$k"
             )
-	    for r in "${!pkg_repo_map[@]}"; do
+            for r in "${!pkg_repo_map[@]}"; do
                 if [[ $r = $k ]]; then
                     dist_repourl_offline+=(
                         "--setopt=$r.mirrorlist="
@@ -1112,7 +1112,7 @@ EOF
                         "--setopt=$r.baseurl=${rocky_repo_offline_baseurls[$r]}"
                     )
                 fi
-	    done
+            done
         done
     fi
 


### PR DESCRIPTION
I added and minimally tested/documented two additional commandline switches for offline migrations and migrations skipping the pre-update step.

These are meant to be used together to facilitate airgapped migrations.