### PR TITLE
Use new sources.openela.org domain for OpenELA lookaside.

### DIFF
--- a/getsrc/getsrc.sh
+++ b/getsrc/getsrc.sh
@@ -16,7 +16,7 @@ https://sources.build.resf.org/%HASH%
 https://git.centos.org/sources/%PKG%/%BRANCH%/%HASH%
 https://sources.stream.centos.org/sources/rpms/%PKG%/%FILENAME%/%SHATYPE%/%HASH%/%FILENAME%
 https://src.fedoraproject.org/repo/pkgs/%PKG%/%FILENAME%/%SHATYPE%/%HASH%/%FILENAME%
-https://ax8edlmsvvfp.compat.objectstorage.us-phoenix-1.oraclecloud.com/mship-srpm1/%HASH%
+http://sources.openela.org/%HASH%
 )
 
 # These are glob patterns.  They should be in the same order as the lookasides

--- a/getsrc/getsrc.sh
+++ b/getsrc/getsrc.sh
@@ -16,7 +16,7 @@ https://sources.build.resf.org/%HASH%
 https://git.centos.org/sources/%PKG%/%BRANCH%/%HASH%
 https://sources.stream.centos.org/sources/rpms/%PKG%/%FILENAME%/%SHATYPE%/%HASH%/%FILENAME%
 https://src.fedoraproject.org/repo/pkgs/%PKG%/%FILENAME%/%SHATYPE%/%HASH%/%FILENAME%
-ttps://ax8edlmsvvfp.compat.objectstorage.us-phoenix-1.oraclecloud.com/mship-srpm1/%HASH%
+https://ax8edlmsvvfp.compat.objectstorage.us-phoenix-1.oraclecloud.com/mship-srpm1/%HASH%
 )
 
 # These are glob patterns.  They should be in the same order as the lookasides

--- a/getsrc/getsrc.sh
+++ b/getsrc/getsrc.sh
@@ -16,6 +16,7 @@ https://sources.build.resf.org/%HASH%
 https://git.centos.org/sources/%PKG%/%BRANCH%/%HASH%
 https://sources.stream.centos.org/sources/rpms/%PKG%/%FILENAME%/%SHATYPE%/%HASH%/%FILENAME%
 https://src.fedoraproject.org/repo/pkgs/%PKG%/%FILENAME%/%SHATYPE%/%HASH%/%FILENAME%
+ttps://ax8edlmsvvfp.compat.objectstorage.us-phoenix-1.oraclecloud.com/mship-srpm1/%HASH%
 )
 
 # These are glob patterns.  They should be in the same order as the lookasides

--- a/getsrc/getsrc.sh
+++ b/getsrc/getsrc.sh
@@ -38,6 +38,7 @@ branches=(
     ''
     ''
     ''
+    ''
 )
 
 declare -A macros

--- a/getsrc/getsrc.sh
+++ b/getsrc/getsrc.sh
@@ -27,6 +27,7 @@ remotes=(
     '@(ssh://git@|http?(s)://)git.centos.org/*'
     '@(ssh://git@|http?(s)://)gitlab.com[:/]redhat/centos-stream/*'
     '@(ssh://git@|http?(s)://)src.fedoraproject.org/*'
+    '@(git@|http?(s)://)github.com[:/]openela-main/*'
 )
 
 # These are branch names that will be glob-matched to to the lookasides above.


### PR DESCRIPTION
Within a week or so HTTPS should be working. For now HTTP can only be used. 