### PR TITLE
add openssl-fips-provider-so

### DIFF
--- a/migrate2rocky/migrate2rocky9.sh
+++ b/migrate2rocky/migrate2rocky9.sh
@@ -727,6 +727,7 @@ collect_system_info () {
     )
     addl_pkg_removes=(
       openssl-fips-provider
+      openssl-fips-provider-so
     )
 
     # Check to make sure that we don't already have a full or partial


### PR DESCRIPTION
Resolves a newer package name for openssl-fips-provider in OL and RHEL.